### PR TITLE
Fix issue #9 by adding package "haskell-src-exts" to stack.yaml file.

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -43,6 +43,7 @@ extra-deps:
 - tz-0.1.2.0
 - dlist-0.7.1.2
 - ghcjs-dom-0.2.4.0
+- haskell-src-exts-1.17.1
 - ref-tf-0.4.0.1
 - prim-uniq-0.1.0.1
 - zenc-0.1.1


### PR DESCRIPTION
Hi @hansroland 
Adding `haskell-src-exts` to the `extra-deps` section of `stack.yaml` is enough to fix the build on my system.
All the best
Jonathan